### PR TITLE
Make pom compatible with maven 3.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<repository>
 			<id>internal</id>
 			<name>Maven 2 Internal Repository</name>
-			<url>http://ccms-support.ucsd.edu/maven2</url>
+			<url>https://ccms-support.ucsd.edu/maven2</url>
 		</repository>
 	</repositories>
 	<pluginRepositories>


### PR DESCRIPTION
HTTP mirrors are no longer supported- see https://maven.apache.org/docs/3.8.1/release-notes.html#cve-2021-26291
Changed to HTTPS